### PR TITLE
chore: drop NewtonSoft

### DIFF
--- a/src/WinForms/coIT.BewirbDich..Winforms.Infrastructure/JsonRepository.cs
+++ b/src/WinForms/coIT.BewirbDich..Winforms.Infrastructure/JsonRepository.cs
@@ -1,6 +1,6 @@
-﻿using System.Text;
+using System.Text;
+using System.Text.Json;
 using coIT.BewirbDich.Winforms.Domain;
-using Newtonsoft.Json;
 
 namespace coIT.BewirbDich.Winforms.Infrastructure;
 
@@ -20,11 +20,11 @@ public class JsonRepository : IRepository
         if (!File.Exists(_file))
         {
             var empty = Enumerable.Empty<Dokument>();
-            File.WriteAllText(_file, JsonConvert.SerializeObject(empty), new UTF8Encoding());
+            File.WriteAllText(_file, JsonSerializer.Serialize(empty), Encoding.UTF8);
         }
 
         var json = File.ReadAllText(_file, Encoding.UTF8);
-        _dokumente = JsonConvert.DeserializeObject<List<Dokument>>(json) ?? new List<Dokument>();
+        _dokumente = JsonSerializer.Deserialize<List<Dokument>>(json) ?? new List<Dokument>();
     }
 
     public Dokument? Find(Guid id)
@@ -44,7 +44,7 @@ public class JsonRepository : IRepository
 
     public void Save()
     {
-        var json = JsonConvert.SerializeObject(_dokumente);
+        var json = JsonSerializer.Serialize(_dokumente);
         File.WriteAllText(_file, json, new UTF8Encoding());
     }
 }

--- a/src/WinForms/coIT.BewirbDich..Winforms.Infrastructure/coIT.BewirbDich.Winforms.Infrastructure.csproj
+++ b/src/WinForms/coIT.BewirbDich..Winforms.Infrastructure/coIT.BewirbDich.Winforms.Infrastructure.csproj
@@ -7,10 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\coIT.BewirbDich.Winforms.Domain\coIT.BewirbDich.Winforms.Domain.csproj" />
     </ItemGroup>
 

--- a/src/web-with-angular-and-web-api/Api/Api.csproj
+++ b/src/web-with-angular-and-web-api/Api/Api.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/web-with-angular-and-web-api/Api/Services/DokumenteService.cs
+++ b/src/web-with-angular-and-web-api/Api/Services/DokumenteService.cs
@@ -1,12 +1,12 @@
 ﻿using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using Api.Domain;
 using Api.Infrastructure;
-using Newtonsoft.Json;
 
 namespace Api.Services;
 
-public class DokumenteService:Repository
+public class DokumenteService : Repository
 {
     private static readonly string JSONPath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "/dokumente.json";
     
@@ -32,11 +32,11 @@ public class DokumenteService:Repository
         if (!File.Exists(JSONPath))
         {
             var empty = Enumerable.Empty<Dokument>();
-            File.WriteAllText(JSONPath, JsonConvert.SerializeObject(empty), new UTF8Encoding());
+            File.WriteAllText(JSONPath, JsonSerializer.Serialize(empty), Encoding.UTF8);
         }
 
         var json = File.ReadAllText(JSONPath, Encoding.UTF8);
-        return JsonConvert.DeserializeObject<List<Dokument>>(json) ?? new List<Dokument>();
+        return JsonSerializer.Deserialize<List<Dokument>>(json) ?? new List<Dokument>();
     }
 
     public Dokument? Find(Guid id)
@@ -64,7 +64,7 @@ public class DokumenteService:Repository
 
     public void Save()
     {
-        var json = JsonConvert.SerializeObject(dokumente);
+        var json = JsonSerializer.Serialize(dokumente);
         File.WriteAllText(JSONPath, json, new UTF8Encoding());
     }
 


### PR DESCRIPTION
Weniger dependencies = gut

Gerade, weil ihr ja auch NET7 setzt, wäre `System.Text.Json` etwas idiomatischer
